### PR TITLE
Убрать вторую ссылку на словарь терминов

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -73,7 +73,6 @@
                         <li><a href="https://rurust.github.io/cargo-docs-ru/" target="blank">Документация по Cargo</a></li>
                         <li><a href="/community-projects.html">Проекты участников нашего сообщества</a></li>
                         <li><a href="/%D1%80%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%B0/2016/03/07/contributing.html">Руководство по участию в проектах</a></li>
-                        <li><a href="/dictionary.html">Словарь терминов</a></li>
                         <li><a href="/in-progress.html">Статьи, над которыми мы работаем</a></li>
                         <li><a href="/contacts.html">Команда</a></li>
                     </ul>


### PR DESCRIPTION
Ссылка на словарь терминов уже есть в меню "Книги"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rurust/rustycrate.ru/176)
<!-- Reviewable:end -->
