### PR TITLE
htmlproofer: Ignore rustlang.org deadlinks for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   bundle exec jekyll build
 - bundle exec htmlproofer ./_site
   --log-level error --only-4xx --check-favicon --check-html --allow-hash-href
-  --url-ignore /crates.io/,/files.gitter.im/,/fonts.googleapis.com/,/www.quora.com/,/is.gd/,'/github.com\/ruRust\/rustycrate.ru\/edit\/master/',/gitter.im/,/cdn.jsdelivr.net/
+  --url-ignore /crates.io/,/files.gitter.im/,/fonts.googleapis.com/,/www.quora.com/,/is.gd/,'/github.com\/ruRust\/rustycrate.ru\/edit\/master/',/gitter.im/,/www.rust-lang.org/,/www.blog.rust-lang.org/,/cdn.jsdelivr.net/
   --file-ignore /yandex_6b9a121b20becc7c.html/,/googlea5495ce52829dd37.html/
 after_success:
 - if [ $TRAVIS_PULL_REQUEST == "false" ] && [ $TRAVIS_BRANCH == "master" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   bundle exec jekyll build
 - bundle exec htmlproofer ./_site
   --log-level error --only-4xx --check-favicon --check-html --allow-hash-href
-  --url-ignore /crates.io/,/files.gitter.im/,/fonts.googleapis.com/,/www.quora.com/,/is.gd/,'/github.com\/ruRust\/rustycrate.ru\/edit\/master/',/gitter.im/,/www.rust-lang.org/,/www.blog.rust-lang.org/,/cdn.jsdelivr.net/
+  --url-ignore /crates.io/,/files.gitter.im/,/fonts.googleapis.com/,/www.quora.com/,/is.gd/,'/github.com\/ruRust\/rustycrate.ru\/edit\/master/',/gitter.im/,/www.rust-lang.org/,/blog.rust-lang.org/,/cdn.jsdelivr.net/
   --file-ignore /yandex_6b9a121b20becc7c.html/,/googlea5495ce52829dd37.html/
 after_success:
 - if [ $TRAVIS_PULL_REQUEST == "false" ] && [ $TRAVIS_BRANCH == "master" ]; then


### PR DESCRIPTION
Attempt to "fix"  #308

I think it's ok to just suppress warnings for dead links to rust-lang.org until https://github.com/rust-lang/www.rust-lang.org/issues/593 is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rurust/rustycrate.ru/309)
<!-- Reviewable:end -->
